### PR TITLE
Rest method updates

### DIFF
--- a/OneLogin/OneLogin.psd1
+++ b/OneLogin/OneLogin.psd1
@@ -35,6 +35,7 @@
         "Remove-OneLoginUserRole",
         "Set-OneLoginUser",
         "Set-OneLoginUserCustomAttribute"
+        "Set-OneLoginUserPasswd"
     )
 
     PrivateData = @{

--- a/OneLogin/functions/Connect-OneLogin.ps1
+++ b/OneLogin/functions/Connect-OneLogin.ps1
@@ -14,6 +14,9 @@ function Connect-OneLogin
         $Region
     )
 
+    # PS Core 6.2 headeer validation fix
+    $PSDefaultParameterValues['Invoke-RestMethod:SkipHeaderValidation'] = $true
+
     $ID = $Credential.UserName
     $Secret = $Credential.GetNetworkCredential().Password
     $ApiBase = "https://api.$Region.onelogin.com"

--- a/OneLogin/functions/Connect-OneLogin.ps1
+++ b/OneLogin/functions/Connect-OneLogin.ps1
@@ -13,7 +13,7 @@ function Connect-OneLogin
         [OneLogin.AdminRegion]
         $Region
     )
-    
+
     $ID = $Credential.UserName
     $Secret = $Credential.GetNetworkCredential().Password
     $ApiBase = "https://api.$Region.onelogin.com"
@@ -21,7 +21,7 @@ function Connect-OneLogin
     $AuthHeader = @{ Authorization = "client_id:$ID, client_secret:$Secret" }
 
     $Body = @{ grant_type = "client_credentials" } | ConvertTo-Json
-    
+
     $Splat = @{
         Uri         = "$ApiBase/$EndPoint"
         Headers     = $AuthHeader

--- a/OneLogin/functions/Set-OneLoginUser.ps1
+++ b/OneLogin/functions/Set-OneLoginUser.ps1
@@ -66,9 +66,15 @@ function Set-OneLoginUser
         $username,
 
         [string]
-        $userprincipalname
+        $userprincipalname,
+
+        [int]
+        $state,
+
+        [int]
+        $status
     )
-    
+
     begin
     {
         $Body = Get-BoundParameter -BoundParameters $PSBoundParameters -ExcludedParameters Identity
@@ -78,7 +84,7 @@ function Set-OneLoginUser
             Body   = $Body
         }
     }
-    
+
     process
     {
         $Splat["Endpoint"] = "api/1/users/$($Identity.Id)"

--- a/OneLogin/functions/Set-OneLoginUser.ps1
+++ b/OneLogin/functions/Set-OneLoginUser.ps1
@@ -44,6 +44,9 @@ function Set-OneLoginUser
         [string]
         $manager_ad_id,
 
+        [int]
+        $manager_user_id,
+
         [string]
         $member_of,
 

--- a/OneLogin/functions/Set-OneLoginUserPasswd.ps1
+++ b/OneLogin/functions/Set-OneLoginUserPasswd.ps1
@@ -1,0 +1,43 @@
+function Set-OneLoginUserPasswd
+{
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "Medium")]
+    param
+    (
+        [Parameter(Mandatory = $true, ValueFromPipeline)]
+        [ValidateNotNullOrEmpty()]
+        [OneLogin.User]
+        $Identity,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $password,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $password_confirmation,
+
+        [string]
+        $validate_policy = $false
+    )
+
+    begin
+    {
+        $Body = Get-BoundParameter -BoundParameters $PSBoundParameters -ExcludedParameters Identity
+
+        $Splat = @{
+            Method = "Put"
+            Body   = $Body
+        }
+    }
+
+    process
+    {
+        $Splat["Endpoint"] = "api/1/users/set_password_clear_text/$($Identity.Id)"
+        if ($PSCmdlet.ShouldProcess($Identity, $MyInvocation.MyCommand.Name))
+        {
+            Invoke-OneLoginRestMethod @Splat
+        }
+    }
+}

--- a/OneLogin/helpers/Invoke-OneLoginRestMethod.ps1
+++ b/OneLogin/helpers/Invoke-OneLoginRestMethod.ps1
@@ -5,7 +5,7 @@ function Invoke-OneLoginRestMethod
     (
         [string]
         $Method = "Get",
-        
+
         [Parameter(Mandatory)]
         [string]
         $Endpoint,
@@ -13,7 +13,7 @@ function Invoke-OneLoginRestMethod
         [hashtable]
         $Body
     )
-    
+
     $Uri = "$($Token.ApiBase)/$Endpoint"
 
     $Splat = @{
@@ -22,7 +22,7 @@ function Invoke-OneLoginRestMethod
         ContentType = "application/json"
         Headers     = @{authorization = "bearer:$($Token.access_token)"}
     }
-    
+
     do
     {
         try
@@ -40,14 +40,14 @@ function Invoke-OneLoginRestMethod
             else { $Body = @{} }
 
 
-            $Response = Invoke-RestMethod @Splat -ErrorAction Stop 
+            $Response = Invoke-RestMethod @Splat -ErrorAction Stop
             $Response.Data
         }
         catch
         {
             throw $_
         }
-        
+
     }
     while ($Response.Pagination.after_cursor -and $Response.data.count -eq 50)
 }

--- a/OneLogin/helpers/Invoke-OneLoginRestMethod.ps1
+++ b/OneLogin/helpers/Invoke-OneLoginRestMethod.ps1
@@ -14,6 +14,9 @@ function Invoke-OneLoginRestMethod
         $Body
     )
 
+    # PS Core 6.2 headeer validation fix
+    $PSDefaultParameterValues['Invoke-RestMethod:SkipHeaderValidation'] = $true
+
     $Uri = "$($Token.ApiBase)/$Endpoint"
 
     $Splat = @{


### PR DESCRIPTION
Set 'Header Validation' in 'Connect-OneLogin' and 'Invoke-OneLoginRestMethod' due to changes in cross-platform PS Core 6.