### PR TITLE
Make Get-OneLoginUser more intuitive when no parameters are passed

### DIFF
--- a/OneLogin/functions/Get-OneLoginUser.ps1
+++ b/OneLogin/functions/Get-OneLoginUser.ps1
@@ -1,10 +1,9 @@
 function Get-OneLoginUser
 {
-    [CmdletBinding(DefaultParameterSetName = "Filter")]
+    [CmdletBinding(DefaultParameterSetName = "All")]
     [OutputType([OneLogin.User])]
     param
     (
-        [CmdletBinding(DefaultParameterSetName = "Filter")]
         [ValidateScript(
             {
                 $EnumValues = [OneLogin.UserFilterParameter].GetEnumNames()
@@ -24,6 +23,7 @@ function Get-OneLoginUser
             }
         )]
         [ValidateNotNullOrEmpty()]
+        [Parameter(ParameterSetName = 'Filter')]
         [hashtable]
         $Filter,
 
@@ -58,6 +58,7 @@ function Get-OneLoginUser
     {
         $OutputType = $PSCmdlet.MyInvocation.MyCommand.OutputType.Type
         (Invoke-OneLoginRestMethod @Splat) | ConvertTo-OneLoginObject -OutputType $OutputType
+        Invoke-OneLoginRestMethod @Splat
     }
     catch
     {

--- a/OneLogin/functions/Get-OneLoginUser.ps1
+++ b/OneLogin/functions/Get-OneLoginUser.ps1
@@ -58,7 +58,6 @@ function Get-OneLoginUser
     {
         $OutputType = $PSCmdlet.MyInvocation.MyCommand.OutputType.Type
         (Invoke-OneLoginRestMethod @Splat) | ConvertTo-OneLoginObject -OutputType $OutputType
-        Invoke-OneLoginRestMethod @Splat
     }
     catch
     {

--- a/tests/Get-OneLoginUser.tests.ps1
+++ b/tests/Get-OneLoginUser.tests.ps1
@@ -30,10 +30,6 @@ Describe "Get-OneLoginUser" {
             {Get-OneLoginUser -Filter @{firstname = $null}} | Should Throw
         }
 
-        It "requires a parameter" {
-            {Get-OneLoginUser} | Should Throw
-        }
-
         Context "-Identity" {
             Mock Invoke-OneLoginRestMethod -ParameterFilter {$Body.ContainsKey("id")} -MockWith {New-UserMock} -Verifiable
 


### PR DESCRIPTION
To me, a new user of the OneLogin PowerShell module, it doesn't make a lot of sense for Get-OneLoginUser to default to a parameter set that has required parameters when there is a parameter set that doesn't technically require any parameters.

I've switched the default parameter set to 'All' so if the command is run without parameters (like what I did the first time I ran it), it will succeed and return all users. The ```-All``` parameter is still preset for backwards compatibility.

Thoughts?