### PR TITLE
Updating API version for Get-OneLoginRole

### DIFF
--- a/OneLogin/functions/Get-OneLoginRole.ps1
+++ b/OneLogin/functions/Get-OneLoginRole.ps1
@@ -37,7 +37,7 @@ function Get-OneLoginRole
     )
     
     $Splat = @{
-        Endpoint = "api/1/roles"
+        Endpoint = "api/2/roles"
     }
     
     switch ($PSCmdlet.ParameterSetName)


### PR DESCRIPTION
API version is now 2 instead of 1